### PR TITLE
Fix the category page in navbar, which was broken initially.

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
                 <div class="navbar-nav font-weight-bold mx-auto py-0">
                     <a href="index.html" class="nav-item nav-link active">Home</a>
                     <a href="about.html" class="nav-item nav-link">About</a>
-                    <a href="Category.html" class="nav-item nav-link">Categories</a>
+                    <a href="category.html" class="nav-item nav-link">Categories</a>
                     <a href="team.html" class="nav-item nav-link">Teams</a>
                     <div class="nav-item dropdown">
                         <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown">Pages</a>


### PR DESCRIPTION
I fix he broken category page on Navbar  category option. I was broken initially because it link with `Category.html` instead of `category.html` this.

Please go through with this and merge it. 