### PR TITLE
fixed access to products and shops page after login

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -24,6 +24,6 @@ document.addEventListener("DOMContentLoaded", function () {
 });
 
 function isUserLoggedIn() {
-const currentUser = localStorage.getItem('currentUser');
-return currentUser !== null;
+  const currentUser = localStorage.getItem('currentUser');
+  return currentUser !== null;
 }

--- a/js/products.js
+++ b/js/products.js
@@ -26,7 +26,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!isUserLoggedIn()) {
         window.location.href = "RegisterPages/register.html";
     }else {
-        document.body.style.display = 'block'; 
+        document.body.classList.remove('d-none'); 
     }
 });
 

--- a/js/shops.js
+++ b/js/shops.js
@@ -23,7 +23,14 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!isUserLoggedIn()) {
         window.location.href = "RegisterPages/register.html";
     }else {
-        document.body.style.display = 'block'; 
+        document.body.classList.remove('d-none');
+    }
+});
+document.addEventListener('DOMContentLoaded', () => {
+    if (!isUserLoggedIn()) {
+        window.location.href = "RegisterPages/register.html"; 
+    } else {
+        document.body.classList.remove('d-none'); 
     }
 });
 

--- a/products.html
+++ b/products.html
@@ -37,16 +37,9 @@
     <link href="css/style.css" rel="stylesheet" />
     <link rel="stylesheet" href="css\footer.css" />
     <link rel="stylesheet" href="css\product.css">
-
-
-    <style>
-      body {
-        display: none; 
-      }
-    </style>
   </head>
 
-  <body>
+  <body class="d-none">
     <!-- Navbar Start -->
     <div class="container-fluid bg-light position-relative shadow">
 
@@ -295,6 +288,7 @@
 
 <!-- Template Javascript -->
 <script src="js/main.js"></script>
+<script src="js/products.js"></script>
 
 <script>
     document.addEventListener("DOMContentLoaded", function() {

--- a/shops.html
+++ b/shops.html
@@ -27,14 +27,9 @@
     <link href="css/style.css" rel="stylesheet">
     <link rel="stylesheet" href="css\footer.css">
     <link rel="stylesheet" href="css\shops.css">
-    <style>
-        body {
-          display: none; 
-        }
-      </style>
 </head>
 
-<body >
+<body class="d-none">
     <!-- Navbar Start -->
     <div class="container-fluid bg-light position-relative shadow">
         <nav class="navbar navbar-expand-lg bg-light navbar-light py-3 py-lg-0 px-0 px-lg-5">
@@ -209,6 +204,7 @@
 
     <!-- Template Javascript -->
     <script src="js/main.js"></script>
+    <script src="js/shops.js"></script>
 
     <script>
         document.addEventListener("DOMContentLoaded", function() {


### PR DESCRIPTION
## Description

Fixed the issue where authenticated users were unable to access the products and shops pages, even when logged in. The issue was caused by `product.js` and `shop.js` not being linked to their respective HTML pages, resulting in the body tag's display being set to none.

### Details
- Found that `auth.js`, `products.js`, and `shop.js` had no bugs.
- The issue stemmed from `product.js` and `shop.js` files not being linked properly to their respective HTML pages.
- This caused the body tag's display to remain hidden for authenticated users, preventing them from viewing products or shops.
- Fixed it by correctly linking the `product.js` and `shop.js` files  in correct order to ensure functionality for authenticated users.

<br/>



## Related Issues

- Closes #369 


<br/>


## Video:
Click [here](https://drive.google.com/file/d/16lZBDeFFzydM30kNJ1LM-JpR8hRWVN9d/view?usp=sharing) to watch the video

##Additional Information:
- I have tested it in brave and chrome browsers. 
- The above video was recorder in Brave browser.

