### PR TITLE
Fixes:#484:The logo of Discord is wrong in Contact Us Page

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -18,6 +18,8 @@
 
     <!-- Font Awesome -->
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.10.0/css/all.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
+
 
     <!-- Flaticon Font -->
     <link href="lib/flaticon/font/flaticon.css" rel="stylesheet">
@@ -177,7 +179,7 @@
                 </p>
                 <div class="d-flex justify-content-start mt-4">
                     <a class="btn btn-outline-primary rounded-circle text-center mr-2 px-0" style="width: 38px; height: 38px" href="https://github.com/mdazfar2/Ezyshop"><i class="fab fa-github"></i></a>
-                    <a class="btn btn-outline-primary rounded-circle text-center mr-2 px-0" style="width: 38px; height: 38px" href="https://discord.com/invite/SEzpxqQG"><i class="fa-brands fa-discord"></i></a>
+                    <a class="btn btn-outline-primary rounded-circle text-center mr-2 px-0" style="width: 38px; height: 38px" href="https://discord.com/invite/SEzpxqQG"><i class="fab fa-discord"></i></a>
                     <a class="btn btn-outline-primary rounded-circle text-center mr-2 px-0" style="width: 38px; height: 38px" href="https://www.linkedin.com/company/ezyshopz/"><i class="fab fa-linkedin-in"></i></a>
                     <a class="btn btn-outline-primary rounded-circle text-center mr-2 px-0" style="width: 38px; height: 38px" href="#"><i class="fab fa-instagram"></i></a>
                 </div>


### PR DESCRIPTION
## Description
The Discord Logo in the footer section of the Contact Us Page was wrong, it is now fixed properly.

## Related Issues

<!--Cite any related issue(s) this pull request addresses. If none, simply state “None”-->
None
- Closes #484


<br/>


## Screenshots / videos (if applicable)
<!--Attach any relevant screenshots or videos demonstrating the changes-->
After:

<img width="1440" alt="Screenshot 2024-10-12 at 7 37 06 PM" src="https://github.com/user-attachments/assets/b212f9a7-1994-45f8-99c7-1518ed49b425">

Before:

<img width="1431" alt="Screenshot 2024-10-12 at 11 07 34 AM" src="https://github.com/user-attachments/assets/a90b5491-5fbd-4dee-81bd-0fcdc55cf07d">


Please give me level1 ,hacktober-fest and gssoc-ext labels.
Thank you


