### PR TITLE
Make shops section responsive & update title in Next.js version

### DIFF
--- a/Benjamin/app/layout.tsx
+++ b/Benjamin/app/layout.tsx
@@ -7,7 +7,7 @@ import Footer from "@/components/footer";
 const font=Urbanist({subsets:['latin']})
 // console.log(font.className)
 export const metadata: Metadata = {
-  title: "Ezyshopz",
+  title: "Ezyshop",
   description: "Store",
 };
 

--- a/Benjamin/components/stores.tsx
+++ b/Benjamin/components/stores.tsx
@@ -52,9 +52,9 @@ const Stores = () => {
         Shop for your favourite products
       </div>
 
-      <div className="h-full flex flex-col gap-10 lg:grid grid-cols-3 lg:gap-20">
+      <div className="h-full flex flex-col gap-5 px-5 md:grid md:grid-cols-2 lg:grid-cols-3 lg:gap-20">
         {cardData.map((card) => (
-          <Card className="w-[400px] hover:scale-105 border border-DarkGray transition duration-300  bg-gray-700">
+          <Card className="sm:w-[400px] md:hover:scale-105 border border-DarkGray transition duration-300  bg-gray-700">
             <CardHeader className="border-b border-DarkGray">
               <div className="flex flex-col gap-2">
                 <img alt="card image" src={card.logo} />

--- a/Benjamin/components/ui/card.tsx
+++ b/Benjamin/components/ui/card.tsx
@@ -23,7 +23,7 @@ const CardHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    className={cn("flex flex-col space-y-1.5 p-3 md:p-6", className)}
     {...props}
   />
 ))
@@ -57,7 +57,7 @@ const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  <div ref={ref} className={cn("p-3 md:p-6 pt-0", className)} {...props} />
 ))
 CardContent.displayName = "CardContent"
 
@@ -67,7 +67,7 @@ const CardFooter = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex items-center p-6 pt-0", className)}
+    className={cn("flex items-center p-3 md:p-6 pt-0", className)}
     {...props}
   />
 ))


### PR DESCRIPTION
## Description
<!--Please include a brief description of the changes-->
This PR addresses the issue where the shops section was not responsive on smaller screen sizes and had an undesirable hover effect on mobile devices. The following changes have been made:

**1. Responsive Shop Cards:**

- Adjusted the layout and size of the shop cards to ensure they display properly on smaller screens.
- Implemented Tailwind CSS classes (e.g., grid-cols-1 sm:grid-cols-2 lg:grid-cols-3) to adapt the layout for different screen sizes.

**2. Hover Effect on Mobile:**

- Disabled the hover effect on shop cards for smaller screens using media queries, ensuring that the enlarging effect only occurs on medium and larger screens.

**3. Title Correction:**

- Updated the title of the Next.js version from Ezyshopz to Ezyshop for consistency across the project.



<br/>



## Related Issues

<!--Cite any related issue(s) this pull request addresses. If none, simply state “None”-->
- Closes #510 


<br/>


## Screenshots / videos (if applicable)
<!--Attach any relevant screenshots or videos demonstrating the changes-->
Click [here](https://drive.google.com/file/d/1T6xuSG1dsk9Fxbf2TChAg8edpTUZsw1c/view?usp=sharing) to watch the screen recording of the result after above changes.
