### PR TITLE
Solved #479 : Wrong Content Render after clearing searchbar

### DIFF
--- a/js/products.js
+++ b/js/products.js
@@ -122,71 +122,6 @@ const products = [
     { product_title: "Cat Litter", product_category: "Pet Supplies", product_shop: "Pet Paradise", product_img_url: "",hover_img_url:"",  product_id: 73, cost: 1199 },
     { product_title: "Dog Leash", product_category: "Pet Supplies", product_shop: "Pet Paradise", product_img_url: "",hover_img_url:"",  product_id: 74, cost: 699 },
 
-    { product_title: "Organic Apples", product_category: "Groceries", product_shop: "Fresh Mart", product_img_url: "", product_id: 19, cost: 52 },
-    { product_title: "Whole Grain Bread", product_category: "Groceries", product_shop: "Green Grocer", product_img_url: "", product_id: 20, cost: 38 },
-    { product_title: "Fresh Milk (1L)", product_category: "Groceries", product_shop: "Fresh Mart", product_img_url: "", product_id: 21, cost: 52 },
-    { product_title: "Eggs (dozen)", product_category: "Groceries", product_shop: "Green Grocer", product_img_url: "", product_id: 22, cost: 82 },
-    { product_title: "Chicken Breast (1kg)", product_category: "Groceries", product_shop: "Fresh Mart", product_img_url: "", product_id: 23, cost: 192 },
-    { product_title: "Fresh Spinach", product_category: "Groceries", product_shop: "Green Grocer", product_img_url: "", product_id: 24, cost: 52 },
-    { product_title: "Rice (5kg)", product_category: "Groceries", product_shop: "Fresh Mart", product_img_url: "", product_id: 25, cost: 92 },
-    { product_title: "Pasta (500g)", product_category: "Groceries", product_shop: "Green Grocer", product_img_url: "", product_id: 26, cost: 42 },
-    { product_title: "Tomato Sauce", product_category: "Groceries", product_shop: "Fresh Mart", product_img_url: "", product_id: 27, cost: 82 },
-    { product_title: "Soy Sauce", product_category: "Groceries", product_shop: "Green Grocer", product_img_url: "", product_id: 29, cost: 82 },
-    
-    // Beauty
-    { product_title: "Moisturizer", product_category: "Beauty", product_shop: "Wellness Center", product_img_url: "",hover_img_url:"",  product_id: 36, cost: 25 },
-    { product_title: "Lipstick", product_category: "Beauty", product_shop: "Wellness Center", product_img_url: "",hover_img_url:"",  product_id: 37, cost: 15 },
-    { product_title: "Facial Cleanser", product_category: "Beauty", product_shop: "Wellness Center", product_img_url: "",hover_img_url:"",  product_id: 38, cost: 20 },
-    { product_title: "Eye Shadow Palette", product_category: "Beauty", product_shop: "Wellness Center", product_img_url: "",hover_img_url:"",  product_id: 39, cost: 30 },
-    { product_title: "Nail Polish", product_category: "Beauty", product_shop: "Wellness Center", product_img_url: "",hover_img_url:"",  product_id: 40, cost: 10 },
-    { product_title: "Sunscreen", product_category: "Beauty", product_shop: "Wellness Center", product_img_url: "",hover_img_url:"",  product_id: 41, cost: 18 },
-    { product_title: "Perfume", product_category: "Beauty", product_shop: "Wellness Center", product_img_url: "",hover_img_url:"",  product_id: 42, cost: 60 },
-    { product_title: "Hair Dryer", product_category: "Beauty", product_shop: "Wellness Center", product_img_url: "",hover_img_url:"",  product_id: 43, cost: 50 },
-    
-    // Sports
-    { product_title: "Running Shoes", product_category: "Sports", product_shop: "Wellness Center", product_img_url: "",hover_img_url:"",  product_id: 44, cost: 70 },
-    { product_title: "Yoga Mat", product_category: "Sports", product_shop: "Wellness Center", product_img_url: "",hover_img_url:"",  product_id: 45, cost: 25 },
-    { product_title: "Dumbbells Set", product_category: "Sports", product_shop: "Wellness Center", product_img_url: "",hover_img_url:"",  product_id: 46, cost: 50 },
-    { product_title: "Tennis Racket", product_category: "Sports", product_shop: "Wellness Center", product_img_url: "",hover_img_url:"",  product_id: 47, cost: 80 },
-    { product_title: "Soccer Ball", product_category: "Sports", product_shop: "Wellness Center", product_img_url: "",hover_img_url:"",  product_id: 48, cost: 30 },
-    { product_title: "Swimming Goggles", product_category: "Sports", product_shop: "Wellness Center", product_img_url: "",hover_img_url:"",  product_id: 49, cost: 15 },
-    { product_title: "Baseball Glove", product_category: "Sports", product_shop: "Wellness Center", product_img_url: "",hover_img_url:"",  product_id: 50, cost: 35 },
-    
-    // Health
-    { product_title: "Multivitamins", product_category: "Health", product_shop: "Wellness Center", product_img_url: "",hover_img_url:"",  product_id: 51, cost: 20 },
-    { product_title: "Protein Powder", product_category: "Health", product_shop: "Wellness Center", product_img_url: "",hover_img_url:"",  product_id: 52, cost: 40 },
-    { product_title: "Blood Pressure Monitor", product_category: "Health", product_shop: "Wellness Center", product_img_url: "",hover_img_url:"",  product_id: 53, cost: 60 },
-    { product_title: "Fitness Tracker", product_category: "Health", product_shop: "Wellness Center", product_img_url: "",hover_img_url:"",  product_id: 54, cost: 70 },
-    { product_title: "Yoga Block", product_category: "Health", product_shop: "Wellness Center", product_img_url: "",hover_img_url:"",  product_id: 55, cost: 15 },
-    
-    // Books
-    { product_title: "The Great Gatsby", product_category: "Books", product_shop: "Book Nook", product_img_url: "",hover_img_url:"",  product_id: 56, cost: 10 },
-    { product_title: "1984", product_category: "Books", product_shop: "RBook Nook", product_img_url: "",hover_img_url:"",  product_id: 57, cost: 12 },
-    { product_title: "To Kill a Mockingbird", product_category: "Books", product_shop: "Book Nook", product_img_url: "",hover_img_url:"",  product_id: 58, cost: 15 },
-    { product_title: "Pride and Prejudice", product_category: "Books", product_shop: "Book Nook", product_img_url: "",hover_img_url:"",  product_id: 59, cost: 10 },
-    { product_title: "Moby Dick", product_category: "Books", product_shop: "Book Nook", product_img_url: "",hover_img_url:"",  product_id: 60, cost: 18 },
-    
-    // Toys
-    { product_title: "Building Blocks", product_category: "Toys", product_shop: "Toy Box", product_img_url: "",hover_img_url:"",  product_id: 63, cost: 30 },
-    { product_title: "Puzzle Game", product_category: "Toys", product_shop: "Toy Box", product_img_url: "",hover_img_url:"",  product_id: 64, cost: 25 },
-    { product_title: "Action Figure", product_category: "Toys", product_shop: "Toy Box", product_img_url: "",hover_img_url:"",  product_id: 65, cost: 20 },
-    { product_title: "Doll Set", product_category: "Toys", product_shop: "Toy Box", product_img_url: "",hover_img_url:"",  product_id: 66, cost: 35 },
-    { product_title: "Remote Control Car", product_category: "Toys", product_shop: "Toy Box", product_img_url: "",hover_img_url:"",  product_id: 67, cost: 45 },
-    
-    // Baby Products
-    { product_title: "Diapers (Pack of 30)", product_category: "Baby Products", product_shop: "Baby Bliss", product_img_url: "",hover_img_url:"",  product_id: 68, cost: 25 },
-    { product_title: "Baby Wipes", product_category: "Baby Products", product_shop: "Baby Bliss", product_img_url: "",hover_img_url:"",  product_id: 69, cost: 10 },
-    { product_title: "Baby Monitor", product_category: "Baby Products", product_shop: "Baby Bliss", product_img_url: "",hover_img_url:"",  product_id: 70, cost: 70 },
-    { product_title: "Baby Stroller", product_category: "Baby Products", product_shop: "Baby Bliss", product_img_url: "",hover_img_url:"",  product_id: 71, cost: 120 },
-    
-    // Automotive
-    { product_title: "Car Wax", product_category: "Automotive", product_shop: "Auto Zone", product_img_url: "",hover_img_url:"",  product_id: 75, cost: 15 },
-    { product_title: "Tire Inflator", product_category: "Automotive", product_shop: "Auto Zone", product_img_url: "",hover_img_url:"",  product_id: 80, cost: 30 },
-    
-    // Pet Supplies
-    { product_title: "Dog Food (10kg)", product_category: "Pet Supplies", product_shop: "Pet Paradise", product_img_url: "",hover_img_url:"",  product_id: 81, cost: 45 },
-    { product_title: "Cat Litter", product_category: "Pet Supplies", product_shop: "Pet Paradise", product_img_url: "",hover_img_url:"",  product_id: 82, cost: 20 },
-    { product_title: "Dog Leash", product_category: "Pet Supplies", product_shop: "Pet Paradise", product_img_url: "",hover_img_url:"",  product_id: 83, cost: 15 },
 ];
 
 
@@ -235,7 +170,7 @@ function updateHeaderName() {
 
 }
 
-function loadProducts() {
+function loadProducts(filteredList = []) {
     if (!filteredProducts.length) {
         if(currentShop != null){
             filteredProducts = products.filter(p => p.product_shop.toLowerCase() === currentShop.toLowerCase());
@@ -247,7 +182,11 @@ function loadProducts() {
     const productsToDisplay = filteredProducts.slice(0, currentPage * productsPerPage);
     displayProducts(productsToDisplay);
 
-    if (productsToDisplay.length === filteredProducts.length) {
+    if (filteredList.length === 0) {
+        document.getElementById('load-more-products').style.display = 'none';
+        document.getElementById('end-message').innerHTML = '<p class="text-center">No Products Found!</p>';
+        document.getElementById('end-message').style.display = 'block';
+    }else if (productsToDisplay.length === filteredProducts.length) {
         document.getElementById('load-more-products').style.display = 'none';
         document.getElementById('end-message').innerHTML = '<p class="text-center">You have reached the end of the products!</p>';
         document.getElementById('end-message').style.display = 'block'; 
@@ -314,31 +253,58 @@ function displayProducts(productList) {
 }
 
 
-
-
-
+function debounce(func, delay) {
+    let timeout;
+    return function () {
+        const context = this;
+        const args = arguments;
+        clearTimeout(timeout);
+        timeout = setTimeout(() => func.apply(context, args), delay);
+    };
+}
 
 function filterProducts() {
     const query = document.getElementById('search-input').value.toLowerCase();
     const container = document.getElementById('product-container');
     currentPage = 1;
 
-    filteredProducts = products.filter(product => 
-        product.product_title.toLowerCase().includes(query) ||
-        product.product_category.toLowerCase().includes(query)
-    );
-    
-    if(filteredProducts.length === 0){
-        document.getElementById('end-message').innerHTML = '<p class="text-center">No products found</p>';
-        document.getElementById('load-more-products').style.display = 'none';
+    const category = getCategoryFromURL();
+    if (query === '') {
+        // If the search query is empty, display all products of the selected category
+        filteredProducts = products.filter(product =>
+            product.product_category.toLowerCase() === category
+        );
+    } else {
+        // Split query into words and filter products based on each word
+        const queryWords = query.split(/\s+/);
+
+        filteredProducts = products.filter(product => {
+            // Ensure the product belongs to the selected category
+            if (product.product_category.toLowerCase() !== category) {
+                return false;
+            }
+
+            // Check if the product title or category matches any word from the query
+            const productTitleWords = product.product_title.toLowerCase().split(/\s+/);
+            return queryWords.every(queryWord =>
+                productTitleWords.some(titleWord => titleWord.startsWith(queryWord))
+            );
+        });
+    }
+
+    if (filteredProducts.length === 0) {
+        // document.getElementById('end-message').innerHTML = '<p class="text-center">No products found</p>';
+        document.getElementById('product-container').style.display = 'none';
     } else {
         document.getElementById('end-message').style.display = 'none';
-        document.getElementById('load-more-products').style.display = 'block'; 
+        document.getElementById('product-container').style.display = '';
     }
-    
-    loadProducts();
+
+    loadProducts(filteredProducts);
     container.scrollIntoView({ behavior: 'smooth' });
 }
+
+const debouncedFilterProducts = debounce(filterProducts, 300);
 
 function loadMoreProducts() {
     currentPage++;

--- a/products.html
+++ b/products.html
@@ -99,9 +99,9 @@
       <div class="row px-2">
         <div class="col-12">
           <div class="input-group search-input-group mb-3">
-            <input type="text" class="form-control search-form-control" id="search-input" placeholder="Search products...">
+            <input type="text" class="form-control search-form-control" id="search-input" placeholder="Search products..." onkeyup="debouncedFilterProducts()">
             <div class="input-group-append search-input-group-append">
-              <button id="search-button" class="btn btn-primary" onclick="filterProducts()">
+              <button id="search-button" class="btn btn-primary">
                 <i class="fas fa-search"></i>
               </button>
             </div>


### PR DESCRIPTION
## Description
<!--Please include a brief description of the changes-->

- Resolved the issue where incorrect content was being rendered after clearing the search bar.
- Implemented a search functionality that filters results based on items starting with the user's input. For example, if a user 
  types "App" in the grocery category, the search will return items that begin with "App."
- Enhanced the search functionality to support items with multiple words. For instance, if a user types "wheat" in the grocery 
   category and there is an item named "whole wheat," that item will be displayed as a result.
- Added debounce functionality to optimize the search. The search now executes only after the user stops typing, instead of on 
  each keystroke, improving performance.
- Removed duplicate entries that were present in the products list array.

<br/>



## Related Issues

<!--Cite any related issue(s) this pull request addresses. If none, simply state “None”-->
- Closes # 479


<br/>


# Screenshots / videos (if applicable)
<!--Attach any relevant screenshots or videos demonstrating the changes-->
https://github.com/user-attachments/assets/3562d45d-b713-4d51-b435-94ff2686889c