### PR TITLE
Email otp signon user

### DIFF
--- a/app/(Customer)/auth/components/signupPage.tsx
+++ b/app/(Customer)/auth/components/signupPage.tsx
@@ -1,77 +1,130 @@
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { AtSign, Phone, User, Eye, EyeOff } from "lucide-react"; // Import Eye and EyeOff
+import { AtSign, Phone, User} from "lucide-react"; // Import Eye and EyeOff
 import React, { useState } from "react";
 import toast from "react-hot-toast";
-import axios from "axios"
+import axios from "axios";
 import { Spinner } from "@/components/ui/spinner";
+import { z } from "zod";
+import {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSlot,
+} from "@/components/ui/input-otp";
+
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { signIn } from "next-auth/react";
 
 interface SignupPageProps {
   switchCss: boolean;
   setSwitchCss: (value: boolean) => void;
   setError: (value: string) => void;
-  loading:boolean,
-  setloading:(value:boolean)=>void;
+  loading: boolean;
+  setloading: (value: boolean) => void;
 }
 
-const SignupPage: React.FC<SignupPageProps> =({ switchCss, setSwitchCss,setError ,loading,setloading}) => {
+// form schema otp
+const FormSchema = z.object({
+  pin: z.string().min(6, {
+    message: "Your one-time password must be 6 characters.",
+  }),
+});
+
+const SignupPage: React.FC<SignupPageProps> = ({
+  switchCss,
+  setSwitchCss,
+  setError,
+  loading,
+  setloading,
+}) => {
+  const [otpOpen, setOtpOpen] = useState(false);
   // State for form fields
   const [fullname, setFullname] = useState("");
   const [mobileNumber, setmobileNumber] = useState("");
   const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [confirmPassword, setConfirmPassword] = useState("");
 
-  // State for showing passwords
-  const [showPassword, setShowPassword] = useState(false);
-  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
+  //  form definition otp
+  const form = useForm<z.infer<typeof FormSchema>>({
+    resolver: zodResolver(FormSchema),
+    defaultValues: {
+      pin: "",
+    },
+  });
+
+  async function onOTPSubmit(data: z.infer<typeof FormSchema>) {
+    // console.log(data.pin+email);
+    setloading(true);
+
+    const result = await signIn("credentials", {
+      email,
+      otp: data.pin,
+      role: "user",
+      redirect: false,
+    });
+    console.log(result);
+    if (!result?.ok) {
+      setError("Invalid email or otp");
+    } else {
+      toast.success(`Welcome!`);
+
+      setTimeout(() => {
+        window.location.href = "/"; // Redirect on success
+      }, 2000);
+    }
+    setloading(false);
+  }
 
   // Handle form submission
-  const handleSubmit = async(e: React.FormEvent) => {
-      setloading(true)
+  const handleSubmit = async (e: React.FormEvent) => {
+    setloading(true);
     e.preventDefault();
 
     // Basic validation
-    if (!fullname || !mobileNumber || !email || !password || !confirmPassword) {
+    if (!fullname || !mobileNumber || !email) {
       setError("All fields are required.");
-      setloading(false)
-      return;
-    }
-    if (password !== confirmPassword) {
-      setError("Passwords do not match.");
-      setloading(false)
+      setloading(false);
       return;
     }
 
-
-    const result = await axios.post('/api/auth/signup',{
+    try {
+      const result = await axios.post("/api/auth/signup", {
         email,
-        password,
-        name:fullname,
-        mobileNumber
-    })
-    console.log(result)
-    if (!result) setError("Invalid email or password");
-    else {
-      toast.success(`Successful, you can login now.`)
-    //   ${session.data?.user?.name}
-      window.location.href = "/login"; // Redirect on success
+        name: fullname,
+        mobileNumber,
+      });
+      console.log(result);
+    } catch (err) {
+      if (axios.isAxiosError(err)) {
+        setError("Invalid email or number, axios error");
+      } else {
+        setError("Invalid email or number");
+      }
+      //
+      console.log(err);
+      setloading(false);
+      return;
     }
-    
-    // Reset form fields after submission
+    setOtpOpen(true);
     setFullname("");
     setmobileNumber("");
-    setEmail("");
-    setPassword("");
-    setConfirmPassword("");
-
-    setloading(false)
+    setloading(false);
   };
 
   return (
     <>
-      {!switchCss && (
-        <div className="flex flex-col dark:text-gray-200 z-10 items-center justify-start pt-12 pl-14 gap-4 w-2/4">
+      {!switchCss && !otpOpen && (
+        <div className="flex flex-col dark:text-gray-200 z-10 items-center justify-start pt-20 pl-14 gap-4 w-2/4">
           <div className="font-nunito text-4xl text-customTeal dark:text-Green font-extrabold">
             Sign Up
           </div>
@@ -109,52 +162,11 @@ const SignupPage: React.FC<SignupPageProps> =({ switchCss, setSwitchCss,setError
               />
               <AtSign className="h-7 w-7 text-customTeal dark:text-Yellow" />
             </div>
-            <div className="flex items-center w-4/5 justify-center mb-4 relative">
-              {" "}
-              {/* Added relative for positioning */}
-              <Input
-                className="rounded-full pr-12" // Added padding for the icon
-                type={showPassword ? "text" : "password"} // Toggle password visibility
-                placeholder="Enter Password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-              />
-              <div
-                className=" cursor-pointer"
-                onClick={() => setShowPassword(!showPassword)}
-              >
-                {showPassword ? (
-                  <EyeOff className="h-7 w-7 text-customTeal dark:text-Yellow" />
-                ) : (
-                  <Eye className="h-7 w-7 text-customTeal dark:text-Yellow" />
-                )}
-              </div>
-            </div>
-            <div className="flex items-center w-4/5 justify-center mb-4 relative">
-              {" "}
-              {/* Added relative for positioning */}
-              <Input
-                className="rounded-full pr-12" // Added padding for the icon
-                type={showConfirmPassword ? "text" : "password"} // Toggle password visibility
-                placeholder="Confirm Password"
-                value={confirmPassword}
-                onChange={(e) => setConfirmPassword(e.target.value)}
-              />
-              <div
-                className="cursor-pointer"
-                onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-              >
-                {showConfirmPassword ? (
-                  <EyeOff className="h-7 w-7 text-customTeal dark:text-Yellow" />
-                ) : (
-                  <Eye className="h-7 w-7 text-customTeal dark:text-Yellow" />
-                )}
-              </div>
-            </div>
+
             <Button
               className="rounded-full h-10 w-4/5 font-bold bg-customTeal dark:bg-Green"
               type="submit"
-              disabled
+              // disabled
             >
               {loading ? <Spinner /> : "Sign Up"}
             </Button>
@@ -169,6 +181,46 @@ const SignupPage: React.FC<SignupPageProps> =({ switchCss, setSwitchCss,setError
             </div>
           </div>
         </div>
+      )}
+      {!switchCss && otpOpen && (
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(onOTPSubmit)}
+            className="flex flex-col dark:text-gray-200 z-10 items-start justify-center pl-14 gap-4 w-2/4"
+          >
+            <FormField
+              control={form.control}
+              name="pin"
+              render={({ field }) => (
+                <FormItem className="flex items-start justify-center flex-col">
+                  <FormLabel className="text-2xl text-customTeal dark:text-Green font-bold">
+                    One-Time Password
+                  </FormLabel>
+                  <FormControl>
+                    <InputOTP maxLength={6} {...field}>
+                      <InputOTPGroup>
+                        <InputOTPSlot index={0} />
+                        <InputOTPSlot index={1} />
+                        <InputOTPSlot index={2} />
+                        <InputOTPSlot index={3} />
+                        <InputOTPSlot index={4} />
+                        <InputOTPSlot index={5} />
+                      </InputOTPGroup>
+                    </InputOTP>
+                  </FormControl>
+                  <FormDescription>
+                    Please enter the one-time password sent to your email.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <Button className="bg-customTeal dark:bg-Green" type="submit">
+              Submit
+            </Button>
+          </form>
+        </Form>
       )}
     </>
   );

--- a/app/(Customer)/auth/role/page.tsx
+++ b/app/(Customer)/auth/role/page.tsx
@@ -1,0 +1,58 @@
+"use client";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { ChevronDown } from "lucide-react";
+import Link from "next/link";
+
+
+const Login = () => {
+  return (
+    <div className="dark:bg-DarkGray ">
+      {/* <div className="bg-slate-700 h-100 w-100">{switchCss ? "1" : "0"}</div>
+      <Button onClick={() => setSwitchCss(!switchCss)}>Toggle CSS</Button> */}
+      <div className="flex h-screen w-full items-center justify-center">
+        <div className="flex rounded-2xl justify-between shadow-xl shadow-black dark:shadow-Green relative lg:h-4/6 lg:w-2/4 border overflow-hidden">
+          {/* First background div */}
+          <div
+            className={`w-full h-full absolute left-60 bottom-[9.5rem] rotate-45 transition-opacity duration-1000 ease-in-out bg-customTeal dark:bg-gradient-to-r from-Green to-Yellow `}
+          ></div>
+          <DropdownMenu>
+            <DropdownMenuTrigger className="flex bg-customTeal dark:bg-Green rounded-full p-5 ml-20 mt-40 h-10 items-center justify-center">
+              Proceed as a
+              <ChevronDown className="h-5 w-5" />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+              <DropdownMenuLabel className="bg-gray-200 dark:bg-DarkGray">
+                Role
+              </DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              <Link href="/auth/customer">
+                <DropdownMenuItem>Customer</DropdownMenuItem>
+              </Link>
+              <Link href="/auth/seller">
+                <DropdownMenuItem>Seller</DropdownMenuItem>
+              </Link>
+              
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          <div
+            className={`text-white flex pt-10 px-4 flex-col w-2/4  z-10 h-full`}
+          >
+            <div className="text-7xl text-right font-handlee font-bold ">
+              Welcome to EzyShop!
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Login;

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from 'next/server';
 import { PrismaClient } from '@prisma/client';
-import bcrypt from 'bcrypt'; 
+import { generateAndSendOTP } from '@/lib/auth';
 
 const prisma = new PrismaClient();
 
 export async function POST(request: Request) {
-  const { email, password , mobileNumber,name } = await request.json();
+  const { email, mobileNumber,name } = await request.json();
 
   // Check if the user already exists
   const existingUser = await prisma.user.findUnique({
@@ -17,19 +17,22 @@ export async function POST(request: Request) {
   }
 
   // Hash the password
-  const passwordHash = await bcrypt.hash(password, 10);
+  // const passwordHash = await bcrypt.hash(password, 10);
   
   // Create the user
   const user = await prisma.user.create({
     data: {
       email,
-      passwordHash,
       mobileNumber,
       name
     },
   });
 
+  generateAndSendOTP(email,"user");
 
 
-  return NextResponse.json({ message: 'Signup successful!',user });
+
+
+
+  return NextResponse.json({ message: 'aCCOUNT CREATED, VERIFY EMAIL VIA OTP',user });
 }

--- a/app/api/auth/signup/seller/route.ts
+++ b/app/api/auth/signup/seller/route.ts
@@ -1,12 +1,12 @@
 import { NextResponse } from 'next/server';
 import { PrismaClient } from '@prisma/client';
-import bcrypt from 'bcrypt'; 
+// import bcrypt from 'bcrypt'; 
 
 const prisma = new PrismaClient();
 
 export async function POST(request: Request) {
-  const { email, password , mobileNumber,name } = await request.json();
-
+  const { email} = await request.json();
+  // storeMobile,name 
   // Check if the user already exists
   const existingUser = await prisma.user.findUnique({
     where: { email },
@@ -16,20 +16,17 @@ export async function POST(request: Request) {
     return NextResponse.json({ message: 'Seller already exists' }, { status: 400 });
   }
 
-  // Hash the password
-  const passwordHash = await bcrypt.hash(password, 10);
   
   // Create the user
-  const user = await prisma.seller.create({
-    data: {
-      email,
-      passwordHash,
-      mobileNumber,
-      name
-    },
-  });
+  // const user = await prisma.seller.create({
+  //   data: {
+  //     email,
+  //     storeMobile,
+  //     name
+  //   },
+  // });
 
 
 
-  return NextResponse.json({ message: 'Signup successful!',user });
+  return NextResponse.json({ message: 'Signup successful!' });
 }

--- a/components/Navbar/authButtons.tsx
+++ b/components/Navbar/authButtons.tsx
@@ -1,26 +1,25 @@
 
 import { signOut, useSession } from "next-auth/react";
-import { useState } from "react";
 import { Button } from "../ui/button";
-import { AuthModal } from "../modals/authModal";
+import Link from "next/link";
 
 const AuthButtons = () => {
 
   
-  const [open, setOpen] = useState(false);
-  const [loading] = useState(false);
+  // const [open, setOpen] = useState(false);
+  // const [loading] = useState(false);
 
   const session=useSession()
   return (
     <div className="flex items-center justify-center gap-2">
       {session.status == "unauthenticated" && (
-        // <Link href={"/login"}>
+        <Link href={"/auth/role"}>
         <Button size={"lg"} className={`bg-customTeal dark:bg-Green  hover:border rounded-xl`}
-        onClick={() => setOpen(true)}
+        // onClick={() => setOpen(true)}
         >
           Login / Signup
         </Button>
-      // </Link>
+      </Link>
       )}
       {session.status == "authenticated" && (
         <>
@@ -28,11 +27,11 @@ const AuthButtons = () => {
           <Button className="rounded-full" variant={"outline"} onClick={() => signOut()}>Log out</Button>
         </>
       )}
-      <AuthModal
+      {/* <AuthModal
           isOpen={open}
           onClose={() => setOpen(false)}
           loading={loading}
-        />
+        /> */}
     </div>
   );
 };

--- a/components/ui/form.tsx
+++ b/components/ui/form.tsx
@@ -1,0 +1,178 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { Slot } from "@radix-ui/react-slot"
+import {
+  Controller,
+  ControllerProps,
+  FieldPath,
+  FieldValues,
+  FormProvider,
+  useFormContext,
+} from "react-hook-form"
+
+import { cn } from "@/lib/utils"
+import { Label } from "@/components/ui/label"
+
+const Form = FormProvider
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+> = {
+  name: TName
+}
+
+const FormFieldContext = React.createContext<FormFieldContextValue>(
+  {} as FormFieldContextValue
+)
+
+const FormField = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>({
+  ...props
+}: ControllerProps<TFieldValues, TName>) => {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  )
+}
+
+const useFormField = () => {
+  const fieldContext = React.useContext(FormFieldContext)
+  const itemContext = React.useContext(FormItemContext)
+  const { getFieldState, formState } = useFormContext()
+
+  const fieldState = getFieldState(fieldContext.name, formState)
+
+  if (!fieldContext) {
+    throw new Error("useFormField should be used within <FormField>")
+  }
+
+  const { id } = itemContext
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  }
+}
+
+type FormItemContextValue = {
+  id: string
+}
+
+const FormItemContext = React.createContext<FormItemContextValue>(
+  {} as FormItemContextValue
+)
+
+const FormItem = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const id = React.useId()
+
+  return (
+    <FormItemContext.Provider value={{ id }}>
+      <div ref={ref} className={cn("space-y-2", className)} {...props} />
+    </FormItemContext.Provider>
+  )
+})
+FormItem.displayName = "FormItem"
+
+const FormLabel = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
+>(({ className, ...props }, ref) => {
+  const { error, formItemId } = useFormField()
+
+  return (
+    <Label
+      ref={ref}
+      className={cn(error && "text-destructive", className)}
+      htmlFor={formItemId}
+      {...props}
+    />
+  )
+})
+FormLabel.displayName = "FormLabel"
+
+const FormControl = React.forwardRef<
+  React.ElementRef<typeof Slot>,
+  React.ComponentPropsWithoutRef<typeof Slot>
+>(({ ...props }, ref) => {
+  const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
+
+  return (
+    <Slot
+      ref={ref}
+      id={formItemId}
+      aria-describedby={
+        !error
+          ? `${formDescriptionId}`
+          : `${formDescriptionId} ${formMessageId}`
+      }
+      aria-invalid={!!error}
+      {...props}
+    />
+  )
+})
+FormControl.displayName = "FormControl"
+
+const FormDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => {
+  const { formDescriptionId } = useFormField()
+
+  return (
+    <p
+      ref={ref}
+      id={formDescriptionId}
+      className={cn("text-[0.8rem] text-muted-foreground", className)}
+      {...props}
+    />
+  )
+})
+FormDescription.displayName = "FormDescription"
+
+const FormMessage = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, children, ...props }, ref) => {
+  const { error, formMessageId } = useFormField()
+  const body = error ? String(error?.message) : children
+
+  if (!body) {
+    return null
+  }
+
+  return (
+    <p
+      ref={ref}
+      id={formMessageId}
+      className={cn("text-[0.8rem] font-medium text-destructive", className)}
+      {...props}
+    >
+      {body}
+    </p>
+  )
+})
+FormMessage.displayName = "FormMessage"
+
+export {
+  useFormField,
+  Form,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+  FormField,
+}

--- a/components/ui/input-otp.tsx
+++ b/components/ui/input-otp.tsx
@@ -1,0 +1,71 @@
+"use client"
+
+import * as React from "react"
+import { DashIcon } from "@radix-ui/react-icons"
+import { OTPInput, OTPInputContext } from "input-otp"
+
+import { cn } from "@/lib/utils"
+
+const InputOTP = React.forwardRef<
+  React.ElementRef<typeof OTPInput>,
+  React.ComponentPropsWithoutRef<typeof OTPInput>
+>(({ className, containerClassName, ...props }, ref) => (
+  <OTPInput
+    ref={ref}
+    containerClassName={cn(
+      "flex items-center gap-2 has-[:disabled]:opacity-50",
+      containerClassName
+    )}
+    className={cn("disabled:cursor-not-allowed", className)}
+    {...props}
+  />
+))
+InputOTP.displayName = "InputOTP"
+
+const InputOTPGroup = React.forwardRef<
+  React.ElementRef<"div">,
+  React.ComponentPropsWithoutRef<"div">
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("flex items-center", className)} {...props} />
+))
+InputOTPGroup.displayName = "InputOTPGroup"
+
+const InputOTPSlot = React.forwardRef<
+  React.ElementRef<"div">,
+  React.ComponentPropsWithoutRef<"div"> & { index: number }
+>(({ index, className, ...props }, ref) => {
+  const inputOTPContext = React.useContext(OTPInputContext)
+  const { char, hasFakeCaret, isActive } = inputOTPContext.slots[index]
+
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        "relative flex h-9 w-9 items-center justify-center border-y border-r border-input text-sm shadow-sm transition-all first:rounded-l-md first:border-l last:rounded-r-md",
+        isActive && "z-10 ring-1 ring-ring",
+        className
+      )}
+      {...props}
+    >
+      {char}
+      {hasFakeCaret && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <div className="h-4 w-px animate-caret-blink bg-foreground duration-1000" />
+        </div>
+      )}
+    </div>
+  )
+})
+InputOTPSlot.displayName = "InputOTPSlot"
+
+const InputOTPSeparator = React.forwardRef<
+  React.ElementRef<"div">,
+  React.ComponentPropsWithoutRef<"div">
+>(({ ...props }, ref) => (
+  <div ref={ref} role="separator" {...props}>
+    <DashIcon />
+  </div>
+))
+InputOTPSeparator.displayName = "InputOTPSeparator"
+
+export { InputOTP, InputOTPGroup, InputOTPSlot, InputOTPSeparator }

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+)
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+))
+Label.displayName = LabelPrimitive.Root.displayName
+
+export { Label }

--- a/lib/nodemailerConfig.ts
+++ b/lib/nodemailerConfig.ts
@@ -1,0 +1,14 @@
+
+import nodemailer from "nodemailer";
+
+const transporter = nodemailer.createTransport({
+  host: process.env.SMTP_HOST, 
+  port: Number(process.env.SMTP_PORT) || 587, 
+  secure: process.env.SMTP_SECURE === 'true', 
+  auth: {
+    user: process.env.SMTP_USER,
+    pass: process.env.SMTP_PASS, 
+  },
+});
+
+export default transporter;

--- a/lib/sendEmail.ts
+++ b/lib/sendEmail.ts
@@ -1,0 +1,23 @@
+
+import transporter from "./nodemailerConfig";
+
+interface EmailOptions {
+  to: string;
+  subject: string;
+  text?: string;
+  html?: string;
+}
+
+const sendEmail = async ({ to, subject, text, html }: EmailOptions) => {
+  const mailOptions = {
+    from: process.env.SMTP_USER,
+    to,
+    subject,
+    text,
+    html,
+  };
+
+  return transporter.sendMail(mailOptions);
+};
+
+export default sendEmail;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,14 @@
       "name": "ezyshop",
       "version": "0.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^3.9.0",
         "@next-auth/prisma-adapter": "^1.0.7",
         "@prisma/client": "^5.21.0",
         "@radix-ui/react-avatar": "^1.1.1",
         "@radix-ui/react-dialog": "^1.1.2",
         "@radix-ui/react-dropdown-menu": "^2.1.2",
         "@radix-ui/react-icons": "^1.3.0",
+        "@radix-ui/react-label": "^2.1.0",
         "@radix-ui/react-navigation-menu": "^1.2.1",
         "@radix-ui/react-popover": "^1.1.2",
         "@radix-ui/react-slot": "^1.1.0",
@@ -27,6 +29,7 @@
         "cmdk": "^1.0.0",
         "embla-carousel-autoplay": "^8.3.0",
         "embla-carousel-react": "^8.3.0",
+        "input-otp": "^1.2.4",
         "lucide-react": "^0.451.0",
         "next": "14.2.14",
         "next-auth": "^4.24.8",
@@ -34,9 +37,11 @@
         "nodemailer": "^6.9.15",
         "react": "^18",
         "react-dom": "^18",
+        "react-hook-form": "^7.53.0",
         "react-hot-toast": "^2.4.1",
         "tailwind-merge": "^2.5.3",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@types/bcrypt": "^5.0.2",
@@ -197,6 +202,15 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
       "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==",
       "license": "MIT"
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.9.0.tgz",
+      "integrity": "sha512-bU0Gr4EepJ/EQsH/IwEzYLsT/PEj5C0ynLQ4m+GSHS+xKH4TfSelhluTgOaoc4kA5s7eCsQbM4wvZLzELmWzUg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
@@ -946,6 +960,29 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.0.tgz",
+      "integrity": "sha512-peLblDlFw/ngk3UWq0VnYaOLy6agTZZ+MUO/WhVfm14vJGML+xH4FAl2XQGLqdefjNb7ApRg6Yn7U42ZhmYXdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -4524,6 +4561,16 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/input-otp": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/input-otp/-/input-otp-1.2.4.tgz",
+      "integrity": "sha512-md6rhmD+zmMnUh5crQNSQxq3keBRYvE3odbr4Qb9g2NWzQv9azi+t1a3X4TBTbh98fsGHgEEJlzbe1q860uGCA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
     "node_modules/internal-slot": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
@@ -6246,6 +6293,22 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.53.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.53.0.tgz",
+      "integrity": "sha512-M1n3HhqCww6S2hxLxciEXy2oISPnAzxY7gvwVPrtlczTM/1dDadXgUxDpHMrMTblDOcm/AXtXxHwZ3jpg1mqKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-hot-toast": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.4.1.tgz",
@@ -7764,6 +7827,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,12 +14,14 @@
     "seed": "node --loader ts-node/esm prisma/seed.ts"
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.9.0",
     "@next-auth/prisma-adapter": "^1.0.7",
     "@prisma/client": "^5.21.0",
     "@radix-ui/react-avatar": "^1.1.1",
     "@radix-ui/react-dialog": "^1.1.2",
     "@radix-ui/react-dropdown-menu": "^2.1.2",
     "@radix-ui/react-icons": "^1.3.0",
+    "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-navigation-menu": "^1.2.1",
     "@radix-ui/react-popover": "^1.1.2",
     "@radix-ui/react-slot": "^1.1.0",
@@ -33,6 +35,7 @@
     "cmdk": "^1.0.0",
     "embla-carousel-autoplay": "^8.3.0",
     "embla-carousel-react": "^8.3.0",
+    "input-otp": "^1.2.4",
     "lucide-react": "^0.451.0",
     "next": "14.2.14",
     "next-auth": "^4.24.8",
@@ -40,9 +43,11 @@
     "nodemailer": "^6.9.15",
     "react": "^18",
     "react-dom": "^18",
+    "react-hook-form": "^7.53.0",
     "react-hot-toast": "^2.4.1",
     "tailwind-merge": "^2.5.3",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,26 +14,51 @@ datasource db {
 }
 
 model User {
-  id            String   @id @default(uuid()) @map("_id")
-  mobileNumber  String   @unique
-  name          String?
-  email         String?  @unique
-  passwordHash  String?
+  id           String  @id @default(uuid()) @map("_id")
+  mobileNumber String  @unique
+  name         String?
+
+  email String? @unique
+  otp   String?
+  role  String  @default("user")
   // addresses     Address[]
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
   // orders        Order[]
   // wishlist      Product[]
 }
+
 model Seller {
-  id            String   @id @default(uuid()) @map("_id")
-  mobileNumber  String   @unique
-  name          String?
-  email         String?  @unique
-  passwordHash  String?
+  id String @id @default(uuid()) @map("_id")
+
+  name         String?
+  storeName    String
+  storeAddress String
+  storeUPI     String
+  storeMobile  String  @unique
+
+  email     String?  @unique
+  otp       String?
+  role      String   @default("seller")
   // addresses     Address[]
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
   // orders        Order[]
   // wishlist      Product[]
 }
+
+// Store Owner Name
+// 2. Store Name
+// 3. Details of Store (in about 20 words)
+// 4. Address --
+// |- City-
+// |- State-
+// |- Colony-
+// |- Nearby-
+
+// 5. Upload Qr Code of your Shop
+
+// 6. Upi Id
+
+// 7. Total products in Shop

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -16,7 +16,7 @@ async function main() {
       mobileNumber: "1234567899",
       name: "John Doe",
       email: "john@examplle.com",
-      passwordHash: hashedPassword1,
+      // passwordHash: hashedPassword1,
     },
   });
 
@@ -25,7 +25,7 @@ async function main() {
       mobileNumber: "0987654322",
       name: "Jane Smith",
       email: "jane@examplee.com",
-      passwordHash: hashedPassword2,
+      // passwordHash: hashedPassword2,
     },
   });
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -50,12 +50,12 @@ const config: Config = {
           "4": "hsl(var(--chart-4))",
           "5": "hsl(var(--chart-5))",
         },
-		customBlue: "#00394f",  // Dark Blue-Green
-        customTeal: "#17a2b8",  // Light Blue
-        Yellow:"#FFC107",
-        Green:"#4CAF50",
+        customBlue: "#00394f", // Dark Blue-Green
+        customTeal: "#17a2b8", // Light Blue
+        Yellow: "#FFC107",
+        Green: "#4CAF50",
         Gray: "#F5F5F5",
-        DarkGray: "#212121"
+        DarkGray: "#212121",
       },
       borderRadius: {
         lg: "var(--radius)",
@@ -64,12 +64,21 @@ const config: Config = {
       },
       fontFamily: {
         handlee: ["Handlee", "cursive"],
-		nunito: ['Nunito', 'sans-serif'],
+        nunito: ["Nunito", "sans-serif"],
+      },
+      keyframes: {
+        "caret-blink": {
+          "0%,70%,100%": { opacity: "1" },
+          "20%,50%": { opacity: "0" },
+        },
+      },
+      animation: {
+        "caret-blink": "caret-blink 1.25s ease-out infinite",
       },
     },
     letterSpacing: {
-      widest: '1.25em',
-    }
+      widest: "1.25em",
+    },
   },
   plugins: [require("tailwindcss-animate")],
 };


### PR DESCRIPTION
## Description
<!--Please include a brief description of the changes-->
This PR replaces the password-based authentication system with a secure email OTP sign-on for users. The following changes were made across the backend and frontend to support this new authentication flow:


<br/>

### Changes Made:

- Added Nodemailer

Configured Nodemailer to handle email delivery using SMTP for sending OTPs.

- Created lib/nodemailerconfig.tsx

Contains the SMTP configuration required to send emails.

- Created lib/sendmail.tsx

Implements the email sending logic for dispatching OTPs to users during login/signup.
Modified NextAuth Configuration

- Updated the authentication provider in nextauth to support OTP-based sign-in.

Removed password verification logic and integrated OTP handling.
Added logic to clear OTP after successful authentication.

- Updated Prisma Schema

Removed the passwordHash field from the User and Seller models.
Added an otp field to store one-time passwords temporarily.

- Updated Frontend UI

Added new components and UI flow to support email OTP login/signup.
Integrated Zod validation for the new OTP-based forms.

- Enhanced Error Handling on Frontend

Implemented full-proof error handling for potential OTP errors during sign-in and signup.
Added proper user feedback for invalid OTPs, expired OTPs, and email input errors.


**Testing & Validation:**
Verified OTP generation, email delivery, and login flows using valid email addresses.


## Related Issues

<!--Cite any related issue(s) this pull request addresses. If none, simply state “None”-->
- Closes #693 


<br/>


## Screenshots / videos (if applicable)
<!--Attach any relevant screenshots or videos demonstrating the changes-->

https://github.com/user-attachments/assets/e7266a1f-1a57-4790-884c-082458bb74c8


https://github.com/user-attachments/assets/6ec4d1c2-7724-48fa-a693-9fbb8deee3e7

