### PR TITLE
Category removal and protection of dashboard from authenticated users with role of "user"

### DIFF
--- a/app/(Customer)/layout.tsx
+++ b/app/(Customer)/layout.tsx
@@ -1,18 +1,38 @@
+"use client";
 import Footer from "@/components/footer";
 import Navbar from "@/components/Navbar/navbar";
+import { useSession } from "next-auth/react";
+import { useEffect, useState } from "react";
 
 export default function Layout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const { data: session, status } = useSession();
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (status === "loading") return; // Don't do anything while loading
+
+    if (status === "authenticated") {
+      if (session.user.role === "seller") {
+        window.location.href = `/${session.user.id}/dashboard`;
+      }
+    }
+    // Set loading to false when authenticated or unauthenticated
+    setLoading(false);
+  }, [session, status]);
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
   return (
-    // <body>
     <>
       <Navbar />
       {children}
       <Footer />
-      </>
-    // {/* </body> */}
+    </>
   );
 }

--- a/app/(Seller)/(routes)/[storeId]/categories/components/cell-action.tsx
+++ b/app/(Seller)/(routes)/[storeId]/categories/components/cell-action.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { CategoryColumn } from "./columns";
 import { Button } from "@/components/ui/button";
-import { Copy, Edit, MoreHorizontal, Trash } from "lucide-react";
+import { Copy, MoreHorizontal, Trash } from "lucide-react";
 import toast from "react-hot-toast";
 import { useParams, useRouter } from "next/navigation";
 import { useState } from "react";

--- a/app/(Seller)/(routes)/[storeId]/categories/components/cell-action.tsx
+++ b/app/(Seller)/(routes)/[storeId]/categories/components/cell-action.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { CategoryColumn } from "./columns";
+import { Button } from "@/components/ui/button";
+import { Copy, Edit, MoreHorizontal, Trash } from "lucide-react";
+import toast from "react-hot-toast";
+import { useParams, useRouter } from "next/navigation";
+import { useState } from "react";
+import axios from "axios";
+import { AlertModal } from "@/components/modals/alert-modal";
+
+interface CellActionProps {
+  data: CategoryColumn;
+}
+
+const CellAction: React.FC<CellActionProps> = ({ data }) => {
+  const onCopy = (id: string) => {
+    navigator.clipboard.writeText(id);
+    toast.success("Category ID copied to the clipboard");
+  };
+
+  const router = useRouter();
+  const params = useParams();
+
+  const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  const onDelete = async () => {
+    try {
+      setLoading(true);
+
+      await axios.delete(
+        `/api/${params.storeId}/categories/${data.id}`
+      );
+
+      router.refresh();
+      toast.success("Category deleted.");
+    } catch {
+      toast.error("Make sure you removed all products using this category");
+    } finally {
+      setLoading(false);
+      setOpen(false);
+    }
+  };
+
+  return (
+    <>
+      <AlertModal 
+        isOpen={open}
+        onClose={()=>setOpen(false)}
+        onConfirm={onDelete}
+        loading={loading}
+      />
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant={"ghost"} className="h-8 w-8 p-0">
+              {/* screen reader only */}
+              <span className="sr-only">Open Menu</span>
+              <MoreHorizontal className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuLabel>Actions</DropdownMenuLabel>
+            <DropdownMenuItem onClick={() => onCopy(data.id)}>
+              <Copy className="h-4 w-4 mr-2" />
+              Copy Id
+            </DropdownMenuItem>
+            
+            <DropdownMenuItem onClick={()=>setOpen(true)}>
+              <Trash className="h-4 w-4 mr-2" />
+              Delete
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+    </>
+  );
+};
+
+export default CellAction;

--- a/app/(Seller)/(routes)/[storeId]/categories/components/columns.tsx
+++ b/app/(Seller)/(routes)/[storeId]/categories/components/columns.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { ColumnDef } from "@tanstack/react-table"
+import CellAction from "./cell-action"
 
 export type CategoryColumn = {
   id: string
@@ -24,4 +25,8 @@ export const columns: ColumnDef<CategoryColumn>[] = [
     accessorKey: "createdAt",
     header: "Date",
   },
+  {
+    id:"actions",
+    cell:({row})=><CellAction data={row.original}/>
+  }
 ]

--- a/app/(Seller)/(routes)/layout.tsx
+++ b/app/(Seller)/(routes)/layout.tsx
@@ -1,23 +1,35 @@
-"use client"
-import {  useSession } from "next-auth/react";
+"use client";
+import { useSession } from "next-auth/react";
+import { useEffect, useState } from "react";
 
 export default function SellerLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const {status} = useSession()
-  if (status === "loading") return <p>Loading...</p>;
-  if (status!=="authenticated") {
-    window.location.href=(`/auth/seller`);
-  }
-  return (
+  const { data: session, status } = useSession();
+  const [loading, setLoading] = useState(true); // State to manage loading
 
-    // <body>
+  useEffect(() => {
+    if (status === "loading") return; // Do nothing while loading
+
+    if (status === "unauthenticated") {
+      window.location.href = `/auth/seller`; // Redirect unauthenticated users
+    } else if (status === "authenticated") {
+      if (session.user.role === "user") {
+        window.location.href = `/`; // Redirect users with role "user"
+      } else if (session.user.role === "seller") {
+        setLoading(false); // Set loading to false for sellers
+      }
+    }
+  }, [session, status]);
+
+  if (loading) return <p>Loading...</p>; // Show loading message until loading is false
+
+  return (
     <>
-      {children}
+      {children} {/* Render children only if role is seller */}
       {/* <Footer /> */}
     </>
-    // {/* </body> */}
   );
 }

--- a/app/api/[storeId]/categories/[categoryId]/route.ts
+++ b/app/api/[storeId]/categories/[categoryId]/route.ts
@@ -1,0 +1,28 @@
+import prismadb from "@/lib/prismadb";
+import { NextResponse } from "next/server";
+
+export async function DELETE(
+    //unused
+    _req:Request,
+    {params}:{params:{storeId:string,categoryId:string}}
+){
+    try{
+        
+        if(!params.categoryId){
+            return new NextResponse("categoryId is required",{status:400})
+
+        }
+
+
+        const category = await prismadb.category.delete({
+            where:{
+                id:params.categoryId
+            }
+        })
+
+        return NextResponse.json(category);
+    }catch(err){
+        console.log('[CATEGORY_DELETE]',err);
+        return new NextResponse("Internal Error",{status:500});
+    }
+}


### PR DESCRIPTION
## Description
<!--Please include a brief description of the changes-->
## 📝 PR Description: Add Category Deletion Functionality

### 🚀 Overview
This PR introduces the **ability to delete Category** from the seller's dashboard. The delete option is added within the **action cells of the ShadCN table**, allowing sellers to manage their Categories conveniently.

---

### 🔧 Implementation Steps
1. **UI Update (Frontend)**  
   - Added a **Delete** button/icon in the **cell actions** of the ShadCN table for Category.
   - This gives sellers a quick way to delete Category directly from the table interface.

2. **API Route for Deletion (Backend)**  
   - Created a **new backend API route** to handle Category deletion.
   - **Protected the route** to ensure only authenticated users can access it.
   - Restricted access to allow sellers to delete **only their own categories**.

3. **Redirection After Deletion**  
   - After a successful deletion, sellers will be **redirected back** to the Category page for better user flow.

---
Additionally I have also added following protection in this PR:
1.If user is "seller" and tries to visit the main website, he will not be allowed to do so for better seperation of concerns.
2.If  a user is authenticated as a user and tries to visit the dashboard page of some seller, they will be redirected back to the main homepage.
<br/>



## Related Issues

<!--Cite any related issue(s) this pull request addresses. If none, simply state “None”-->
- Closes #803 


<br/>


## Screenshots / videos (if applicable)
<!--Attach any relevant screenshots or videos demonstrating the changes-->

https://github.com/user-attachments/assets/881f9e90-32a2-426f-9b99-873426c75fe7

