### PR TITLE
Make the both navbar Sticky

### DIFF
--- a/components/Navbar/navbar.tsx
+++ b/components/Navbar/navbar.tsx
@@ -11,9 +11,9 @@ const Navbar = () => {
 
   return (
     <div
-      className={`border-b  dark:border-Green w-full border-gray-900 ${
+      className={`border-b dark:border-Green w-full border-gray-900 ${
         theme === "dark" ? "bg-DarkGray" : "bg-white"
-      }`}
+      } sticky top-0 z-50`}  // <-- Added `sticky`, `top-0`, and `z-50` for sticky effect
     >
       <div
         className={`relative px-4 sm:px-6 lg:px-8 flex h-25 justify-between items-center ${

--- a/components/Navbar/sellerNav.tsx
+++ b/components/Navbar/sellerNav.tsx
@@ -13,9 +13,9 @@ const SellerNavbar = () => {
 
   return (
     <div
-      className={`border-b  dark:border-Green w-full border-gray-900 ${
+      className={`border-b dark:border-Green w-full border-gray-900 ${
         theme === "dark" ? "bg-DarkGray" : "bg-white"
-      }`}
+      } sticky top-0 z-50`}  // <-- Added `sticky`, `top-0`, and `z-50` for sticky effect
     >
       <div
         className={`relative px-4 sm:px-6 lg:px-8 flex h-25 justify-between items-center ${


### PR DESCRIPTION
## Description
<!--Please include a brief description of the changes-->
1)   I make the navbar sticky for both mobile and desktop. I make the both navbar sticky, seller nav & also customer nav as per the  ISSUE #730 

2) I fix the mobile navbar problem for cart page, where the mobile dropdown menubar background is transparent, So i increase the Z - index. As per the ISSUE #791 



<br/>



## Related Issues

<!--Cite any related issue(s) this pull request addresses. If none, simply state “None”-->
- Closes #

**Fix two ISSUE**
One is #730 
Second is #791 

<br/>


## Screenshots / videos (if applicable)
<!--Attach any relevant screenshots or videos demonstrating the changes-->
Solved first ISSUE  #730 

https://github.com/user-attachments/assets/9b718923-0e71-4d8a-925e-51e0eb138185



<br/>

Solved second ISSUE  #791 

https://github.com/user-attachments/assets/6d687d68-29fa-47f9-b531-5479aac4e3df


@mdazfar2   Please check it out and Don't forget to add all labels for `two ISSUE`

One is for #730  another one for #791 that is `label-2` & `label-2`  and also rest other label under gssoc & hacktoberfest please.

**Thank You**
