### PR TITLE
 Added gap between Trending Deals Cards

### DIFF
--- a/components/categories.tsx
+++ b/components/categories.tsx
@@ -238,7 +238,7 @@ const Categories = ({ showLoadMore = true }) => {
           {remainingStores.map((card) => (
             <Card
               key={card.title}
-              className="sm:w-[400px] md:hover:scale-105 transition duration-300 bg-gray-200 dark:bg-gray-700 "
+              className="sm:w-[400px] md:hover:scale-105 mb-6 transition duration-300 bg-gray-200 dark:bg-gray-700 "
             >
               <CardHeader className="dark:border-DarkGray p-0">
                 <div className="flex flex-col gap-2">


### PR DESCRIPTION
This pull request addresses the bug where the **Trending Deals** cards were overlapping and touching the bottom of other cards when hovered. This issue affected the visual hierarchy and led to a cluttered appearance on hover.

#### Problem:
- When hovering over the **Trending Deals** cards, the card edges were touching the bottom of adjacent cards, creating a disorganized layout.
- This bug disrupted the overall user experience and made the UI appear less polished.

![image](https://github.com/user-attachments/assets/0072088b-fcc6-4891-a46c-8a4c7fe05a83)
