### PR TITLE
Add Admin Dashboard Page with Metrics and Recent Sales

### DIFF
--- a/app/(Customer)/(footerPages)/contributors/page.tsx
+++ b/app/(Customer)/(footerPages)/contributors/page.tsx
@@ -4,6 +4,7 @@ import ContributorCard from "@/components/contributorCard";
 import { Spinner } from "@/components/ui/spinner";
 import ReactConfetti from "react-confetti";
 import { useEffect, useState, useRef } from "react";
+import Image from "next/image";
 
 interface Contributor {
   login: string;
@@ -141,28 +142,33 @@ const ContributorsPage = () => {
               <div className="mt-10">
                 <div className="flex w-full justify-between items-center">
                   {/* First Image on the Left */}
-                  <div className="flex md:w-1/4 md:mr-auto hidden md:block">
-                    <img
+                  <div className="flex md:w-1/4 md:mr-auto md:block">
+                    <Image
+                      width={1000}
+                      height={1000}
                       src="/left_green.png"
                       className="hidden dark:block"
                       alt=""
                     />
-                    <img src="/left_blue.png" className="dark:hidden" />
+                    <Image
+                      width={1000}
+                      height={1000} alt="" src="/left_blue.png" className="dark:hidden" />
                   </div>
                   <div className="flex flex-col items-center md:flex-row  h-full md:pt-1">
                     {/* First Contributor (index 2) */}
 
                     <div className="text-center mt-5 w-64 mx-auto md:mx-3 md:w-48 md:mt-10 order-2 md:order-1">
                       <div className="relative inline-block transform transition-transform duration-300 hover:scale-110 cursor-pointer">
-                        <img
+                        <Image
+                          width={1000}
+                          height={1000}
                           alt=""
                           className="rounded-full border-8 border-customTeal dark:border-Green"
                           onClick={() =>
                             window.open(contributors[2].html_url, "_blank")
                           }
-                          height="140"
                           src={contributors[2].avatar_url}
-                          width="140"
+                
                         />
                         <div className="absolute bottom-0 right-0 bg-customTeal dark:bg-[#e9be1e] text-white rounded-full w-10 h-10 flex items-center justify-center text-xl">
                           2
@@ -197,37 +203,46 @@ const ContributorsPage = () => {
 
                     {/* Second Contributor (index 1) */}
                     <div className="relative text-center w-64 mx-auto md:mx-5  md:w-64 flex-shrink-0 order-1 md:order-2">
-                      <img
+                      <Image
+                        width={1000}
+                        height={1000}
                         src="/glitter_green_right.png"
                         alt="Glitter decoration"
                         className="absolute -top-10 -right-10 w-16 h-16 hidden dark:block"
                       />
-                      <img
+                      <Image
+                        width={1000}
+                        height={1000}
                         src="/glitter_blue_right.png"
                         alt="Glitter decoration"
                         className="absolute -top-10 -right-10 w-16 h-16 dark:hidden"
                       />
-                      <img
+                      <Image
+                        width={1000}
+                        height={1000}
                         src="/glitter_green_left.png"
                         alt="Glitter decoration"
                         className="absolute -top-10 -left-10 w-16 h-16 hidden dark:block"
                       />
-                      <img
+                      <Image
+                        width={1000}
+                        height={1000}
                         src="/glitter_blue_left.png"
                         alt="Glitter decoration"
                         className="absolute -top-10 -left-10 w-16 h-16 dark:hidden"
                       />
 
                       <div className="relative inline-block transform transition-transform duration-300 hover:scale-110 cursor-pointer">
-                        <img
+                        <Image
+                          width={1000}
+                          height={1000}
                           alt="A person in a suit working on a laptop and holding a phone"
                           className="rounded-full border-8 border-customTeal dark:border-Green"
                           onClick={() =>
                             window.open(contributors[1].html_url, "_blank")
                           }
-                          height="180"
                           src={contributors[1].avatar_url}
-                          width="180"
+                       
                         />
                         <div className="absolute bottom-0 right-0 bg-customTeal dark:bg-[#e9be1e] text-white rounded-full w-12 h-12 flex items-center justify-center text-xl">
                           1
@@ -263,15 +278,16 @@ const ContributorsPage = () => {
                     {/* Third Contributor (index 3) */}
                     <div className="text-center mt-5 w-64 mx-auto md:mx-3 md:w-48 md:mt-10 order-3 md:order-3">
                       <div className="relative inline-block transform transition-transform duration-300 hover:scale-110 cursor-pointer">
-                        <img
+                        <Image
+                          width={1000}
+                          height={1000}
                           alt="A person in a suit working on a laptop and holding a phone"
                           className="rounded-full border-8 border-customTeal dark:border-Green"
                           onClick={() =>
                             window.open(contributors[3].html_url, "_blank")
                           }
-                          height="140"
                           src={contributors[3].avatar_url}
-                          width="140"
+                    
                         />
                         <div className="absolute bottom-0 right-0 bg-customTeal dark:bg-[#e9be1e] text-white rounded-full w-10 h-10 flex items-center justify-center text-xl">
                           3
@@ -304,13 +320,17 @@ const ContributorsPage = () => {
                       </div>
                     </div>
                   </div>
-                  <div className="flex md:h-auto md:w-1/4 hidden md:block">
-                    <img
+                  <div className="flex md:h-auto md:w-1/4 md:block">
+                    <Image
+                      width={1000}
+                      height={1000}
                       src="/right_green.png"
                       className="hidden dark:block"
                       alt=""
                     />
-                    <img src="/right_blue.png" className="dark:hidden" />
+                    <Image
+                      width={1000}
+                      height={1000} alt="" src="/right_blue.png" className="dark:hidden" />
                   </div>
                 </div>
               </div>

--- a/app/(Customer)/(footerPages)/forum/components/NewQuestionForm.tsx
+++ b/app/(Customer)/(footerPages)/forum/components/NewQuestionForm.tsx
@@ -6,7 +6,7 @@ import { Label } from '@/components/ui/label';
 import { Spinner } from '@/components/ui/spinner';
 import { Textarea } from '@/components/ui/textarea';
 import { useSession } from 'next-auth/react';
-import { SyntheticEvent, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 const NewQuestionForm = () => {
   const [questionContent, setQuestionContent] = useState('');
@@ -31,7 +31,7 @@ const NewQuestionForm = () => {
     return <Spinner />;
   }
 
-  const handleSubmit = async (e: SyntheticEvent) => {
+  const handleSubmit = async () => {
     // e.preventDefault();
     try {
       const response = await createQuestion(questionContent);

--- a/app/(Customer)/(footerPages)/forum/components/NewQuestionForm.tsx
+++ b/app/(Customer)/(footerPages)/forum/components/NewQuestionForm.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { createQuestion } from '@/actions/forum/Question';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Spinner } from '@/components/ui/spinner';
+import { Textarea } from '@/components/ui/textarea';
+import { useSession } from 'next-auth/react';
+import { SyntheticEvent, useEffect, useState } from 'react';
+
+const NewQuestionForm = () => {
+  const [questionContent, setQuestionContent] = useState('');
+  const [submissionError, setSubmissionError] = useState('');
+
+  const [isMounted, setIsMounted] = useState(false);
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+  const session = useSession();
+
+  useEffect(() => {
+    setIsMounted(true);
+    if (!(session.status === 'loading')) {
+      if (session.status === 'authenticated') {
+        setIsAuthenticated(true);
+        // console.log("hereeeeeeeeee"+isAuthenticated+session.status)
+      }
+    }
+  }, [session.status]);
+
+  if (!isMounted) {
+    return <Spinner />;
+  }
+
+  const handleSubmit = async (e: SyntheticEvent) => {
+    // e.preventDefault();
+    try {
+      const response = await createQuestion(questionContent);
+      if (!response.success && response.error) {
+        setSubmissionError(response.error);
+      } else {
+        setQuestionContent('');
+        setSubmissionError('');
+      }
+    } catch (error) {
+      setSubmissionError(
+        'An error occurred while submitting your question. Please try again.'
+      );
+    }
+  };
+
+  return (
+    <>
+      {isAuthenticated ? (
+        <form onSubmit={handleSubmit} className="space-y-4 w-2/4">
+          <Label htmlFor="new-question" className="text-gray-700 font-medium">
+            Your Question
+          </Label>
+          <Textarea
+            id="new-question"
+            value={questionContent}
+            onChange={e => setQuestionContent(e.target.value)}
+            placeholder="Type your question here..."
+            className="resize-none w-full rounded-md border-gray-300 focus:border-indigo-500"
+            required
+          />
+          {submissionError && <p className="text-red-600">{submissionError}</p>}
+          <Button type="submit" className="w-full dark:bg-Green bg-customTeal text-white">
+            Submit Question
+          </Button>
+        </form>
+      ) : (
+        <p className="text-red-500 text-sm">
+          Please authenticate yourself to post a question.
+        </p>
+      )}
+    </>
+  );
+};
+
+export default NewQuestionForm;

--- a/app/(Customer)/(footerPages)/forum/components/unAnsweredQuestions.tsx
+++ b/app/(Customer)/(footerPages)/forum/components/unAnsweredQuestions.tsx
@@ -36,7 +36,7 @@ const UnansweredQuestionCard: React.FC<UnansweredQuestionCardProps> = ({ questio
     return <Spinner />;
   }
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async () => {
     // e.preventDefault();
     setIsSubmitting(true);
 

--- a/app/(Customer)/(footerPages)/forum/components/unAnsweredQuestions.tsx
+++ b/app/(Customer)/(footerPages)/forum/components/unAnsweredQuestions.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Spinner } from "@/components/ui/spinner";
+import { useEffect, useState } from "react";
+import { useSession } from "next-auth/react";
+import toast from "react-hot-toast"; // Assuming you're using React Hot Toast for notifications
+import { createAnswer } from "@/actions/forum/Answer"; // Import the server action
+
+interface UnansweredQuestionCardProps {
+  question: {
+    id: string;
+    content: string;
+  };
+}
+
+const UnansweredQuestionCard: React.FC<UnansweredQuestionCardProps> = ({ question }) => {
+  const [answer, setAnswer] = useState("");
+  const [isMounted, setIsMounted] = useState(false);
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const { status: sessionStatus } = useSession();
+
+  useEffect(() => {
+    setIsMounted(true);
+    if (sessionStatus === "authenticated") {
+      setIsAuthenticated(true);
+    }
+  }, [sessionStatus]);
+
+  if (!isMounted) {
+    return <Spinner />;
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    // e.preventDefault();
+    setIsSubmitting(true);
+
+    try {
+      const response = await createAnswer(question.id, answer);
+
+      if (response.success) {
+        toast.success("Answer submitted successfully!");
+        setAnswer(""); // Clear the textarea on success
+      } else {
+        toast.error(response.error || "An error occurred while submitting your answer.");
+      }
+    } catch (error) {
+      toast.error("An error occurred while submitting your answer. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Card key={question.id} className="bg-gray-200 dark:bg-gray-700">
+      <CardHeader>
+        <CardTitle>{question.content}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isAuthenticated ? (
+          <form onSubmit={handleSubmit}>
+            <div className="space-y-4">
+              <Label htmlFor={`answer-${question.id}`} className="block text-sm font-medium text-gray-600">
+                Your Answer
+              </Label>
+              <Textarea
+                id={`answer-${question.id}`}
+                value={answer}
+                onChange={(e) => setAnswer(e.target.value)}
+                placeholder="Type your answer here..."
+                className="resize-none w-full rounded-md border-gray-300 focus:border-indigo-500"
+                required
+                disabled={isSubmitting}
+              />
+            </div>
+            <Button type="submit" className="mt-4 w-full bg-customTeal dark:bg-Green text-white" disabled={isSubmitting}>
+              {isSubmitting ? "Submitting..." : "Submit Answer"}
+            </Button>
+          </form>
+        ) : (
+          <p className="text-red-500 text-sm">Please authenticate yourself to answer the question.</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default UnansweredQuestionCard;

--- a/app/(Customer)/(footerPages)/forum/page.tsx
+++ b/app/(Customer)/(footerPages)/forum/page.tsx
@@ -1,0 +1,90 @@
+import {
+  getAnsweredQuestions,
+  getUnansweredQuestions,
+} from "@/actions/forum/Question";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import NewQuestionForm from "./components/NewQuestionForm";
+import UnansweredQuestionCard from "./components/unAnsweredQuestions";
+
+const Forum = async () => {
+  const unansweredResp = await getUnansweredQuestions();
+  const answeredResp = await getAnsweredQuestions();
+
+  return (
+    <div className="container mx-auto p-6 space-y-8">
+      {/* Page Title */}
+      <div className="h-full">
+        <div className="text-white flex items-center justify-center bg-customTeal dark:bg-gradient-to-r from-Green to-Yellow h-full mb-20 p-24">
+          <div className="text-4xl pt-5 lg:pt-0 lg:text-7xl text-center lg:text-start font-extrabold text-gray-200 font-handlee">
+            Forum
+          </div>
+        </div>
+      </div>
+
+      {/* Ask a New Question Section */}
+      <section className="space-y-4 flex items-center justify-center flex-col">
+        <h2 className="text-2xl font-semibold font-handlee flex items-center justify-center text-gray-700">Ask a Question</h2>
+        <NewQuestionForm />
+      </section>
+
+      {/* Unanswered Questions Section */}
+      <section className="space-y-6">
+        <h2 className="text-2xl font-semibold text-gray-700">
+          Unanswered Questions
+        </h2>
+
+        {unansweredResp.success ? (
+          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+            {unansweredResp.data?.map((question) => (
+              <UnansweredQuestionCard key={question.id} question={question} />
+            ))}
+          </div>
+        ) : (
+          <p className="text-gray-600">
+            {unansweredResp.error || "No unanswered questions available."}
+          </p>
+        )}
+      </section>
+
+      {/* Answered Questions Section */}
+      <section className="space-y-6">
+        <h2 className="text-2xl font-semibold text-gray-700">
+          Answered Questions
+        </h2>
+
+        {answeredResp.success ? (
+          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+            {answeredResp.data?.map((question) => (
+              <Card key={question.id} className="bg-gray-200 dark:bg-gray-700 ">
+                <CardHeader>
+                  <CardTitle>{question.content}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="space-y-2">
+                    <p className="text-sm font-medium text-gray-700">
+                      Answers:
+                    </p>
+                    {question.answers?.map((answer) => (
+                      <div
+                        key={answer.id}
+                        className="p-3 bg-gray-100 rounded-md"
+                      >
+                        <p className="text-gray-800">{answer.content}</p>
+                      </div>
+                    ))}
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        ) : (
+          <p className="text-gray-600">
+            {answeredResp.error || "No answered questions available."}
+          </p>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default Forum;

--- a/app/admin/[adminId]/components/overview.tsx
+++ b/app/admin/[adminId]/components/overview.tsx
@@ -1,0 +1,36 @@
+"use client";
+import { Bar, BarChart, ResponsiveContainer, XAxis, YAxis } from "recharts";
+
+interface graphData{
+    name:string,
+    total:number
+}
+interface OverviewProps {
+  data:graphData[]
+}
+
+const Overview: React.FC<OverviewProps> = ({ data }) => {
+  return (
+    <ResponsiveContainer width="100%" height={350}>
+      <BarChart data={data}>
+        <XAxis
+          dataKey={"name"}
+          stroke="#888888"
+          fontSize={12}
+          tickLine={false}
+          axisLine={false}
+        />
+        <YAxis
+          stroke="#888888"
+          fontSize={12}
+          tickLine={false}
+          axisLine={false}
+          tickFormatter={(value) => `₹${value}`}
+        />
+        <Bar dataKey="total" fill="#3498db" radius={[4, 4, 0, 0]} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+};
+
+export default Overview;

--- a/app/admin/[adminId]/components/recentSales.tsx
+++ b/app/admin/[adminId]/components/recentSales.tsx
@@ -1,0 +1,83 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Card } from "@/components/ui/card";
+
+interface Sale {
+  name: string;
+  email: string;
+  avatarSrc: string;
+  avatarText: string;
+  amount: number;
+  storeName: string;
+}
+
+const salesData: Sale[] = [
+  {
+    name: "Amit Sharma",
+    email: "amit.sharma@ezyshop.in",
+    avatarSrc: "/avatars/amit.png",
+    avatarText: "AS",
+    amount: 1999.0,
+    storeName: "Sharma Electronics",
+  },
+  {
+    name: "Priya Gupta",
+    email: "priya.gupta@ezyshop.in",
+    avatarSrc: "/avatars/priya.png",
+    avatarText: "PG",
+    amount: 39.0,
+    storeName: "Priya's Boutique",
+  },
+  {
+    name: "Ravi Kumar",
+    email: "ravi.kumar@ezyshop.in",
+    avatarSrc: "/avatars/ravi.png",
+    avatarText: "RK",
+    amount: 299.0,
+    storeName: "Ravi's Tech Store",
+  },
+  {
+    name: "Neha Yadav",
+    email: "neha.yadav@ezyshop.in",
+    avatarSrc: "/avatars/neha.png",
+    avatarText: "NY",
+    amount: 99.0,
+    storeName: "Neha's Fashion",
+  },
+  {
+    name: "Sahil Verma",
+    email: "sahil.verma@ezyshop.in",
+    avatarSrc: "/avatars/sahil.png",
+    avatarText: "SV",
+    amount: 39.0,
+    storeName: "Sahil's Grocery",
+  },
+];
+
+export function RecentSales() {
+  return (
+    <div className="space-y-8 flex items-center justify-center flex-col">
+      {salesData.map((sale, index) => (
+        <div className="flex items-center w-full lg:w-3/4 bg-gray-200 dark:bg-gray-700 p-2 rounded-xl" key={index}>
+          <Avatar className="h-9 w-9">
+            <AvatarImage src={sale.avatarSrc} alt={sale.name} />
+            <AvatarFallback>{sale.avatarText}</AvatarFallback>
+          </Avatar>
+          <div className="grid grid-cols-1 gap-2 lg:grid-cols-2">
+            <div className="ml-4 space-y-1  p-2 col-span-1">
+              <p className="text-sm font-medium leading-none">{sale.name}</p>
+              <p className="text-sm text-muted-foreground">{sale.email}</p>
+            </div>
+            <div className="ml-4 space-y-1  p-2 col-span-1">
+              <div className="ml-auto text-sm font-medium">
+                +₹{sale.amount.toLocaleString()}
+              </div>
+              <p className="ml-auto text-sm text-muted-foreground">
+                {sale.storeName}
+              </p>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/app/admin/[adminId]/components/recentSales.tsx
+++ b/app/admin/[adminId]/components/recentSales.tsx
@@ -1,5 +1,4 @@
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Card } from "@/components/ui/card";
 
 interface Sale {
   name: string;

--- a/app/admin/[adminId]/page.tsx
+++ b/app/admin/[adminId]/page.tsx
@@ -2,7 +2,6 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Heading } from "@/components/ui/heading";
 import { Separator } from "@/components/ui/separator";
-import { formatter } from "@/lib/utils";
 import { Activity, CreditCard, IndianRupee, Package, Store, User } from "lucide-react";
 import { RecentSales } from "./components/recentSales";
 import Overview from "./components/overview";
@@ -26,7 +25,7 @@ const mockGraphData = [
     { name: "Dec", total: 10000 },
   ];
 
-const AdminPage: React.FC<AdminPageProps> = async ({ params }) => {
+const AdminPage: React.FC<AdminPageProps> = async () => {
 
   return (
     <div className="flex-col">

--- a/app/admin/[adminId]/page.tsx
+++ b/app/admin/[adminId]/page.tsx
@@ -1,9 +1,127 @@
-const AdminPage = () => {
-    return ( 
-        <div>
-            Hi
-        </div>
-     );
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Heading } from "@/components/ui/heading";
+import { Separator } from "@/components/ui/separator";
+import { formatter } from "@/lib/utils";
+import { Activity, CreditCard, IndianRupee, Package, Store, User } from "lucide-react";
+import { RecentSales } from "./components/recentSales";
+import Overview from "./components/overview";
+
+interface AdminPageProps {
+  params: { storeId: string };
 }
- 
+
+const mockGraphData = [
+    { name: "Jan", total: 5000 },
+    { name: "Feb", total: 4500 },
+    { name: "Mar", total: 6000 },
+    { name: "Apr", total: 5500 },
+    { name: "May", total: 7000 },
+    { name: "Jun", total: 8000 },
+    { name: "Jul", total: 7500 },
+    { name: "Aug", total: 7000 },
+    { name: "Sep", total: 8500 },
+    { name: "Oct", total: 9000 },
+    { name: "Nov", total: 9500 },
+    { name: "Dec", total: 10000 },
+  ];
+
+const AdminPage: React.FC<AdminPageProps> = async ({ params }) => {
+
+  return (
+    <div className="flex-col">
+      <div className="flex-1 space-y-4 p-8 pt-6">
+        <Heading title="Dashboard" description="Overview of the website" />
+        <Separator />
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2  lg:grid-cols-3">
+          <Card className="bg-gray-200 dark:bg-gray-700">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">
+                Total Revenue
+              </CardTitle>
+
+              <IndianRupee className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">
+              ₹ 2,10,789
+              </div>
+            </CardContent>
+          </Card>
+          <Card className="bg-gray-200 dark:bg-gray-700">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Sales</CardTitle>
+
+              <CreditCard className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+              +577
+            </CardContent>
+          </Card>
+          <Card className="bg-gray-200 dark:bg-gray-700">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">
+                Stores Associated
+              </CardTitle>
+
+              <Store className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+              43
+            </CardContent>
+          </Card>
+          <Card className="bg-gray-200 dark:bg-gray-700">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">
+                Customer Associated
+              </CardTitle>
+
+              <User className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+                1450
+            </CardContent>
+          </Card>
+          <Card className="bg-gray-200 dark:bg-gray-700">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">
+                Website Visits
+              </CardTitle>
+
+              <Activity className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+                100,223
+            </CardContent>
+          </Card>
+          <Card className="bg-gray-200 dark:bg-gray-700">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">
+                Successful Orders
+              </CardTitle>
+
+              <Package className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+                20455+
+            </CardContent>
+          </Card>
+        </div>
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <Card className="col-span-1">
+            <CardHeader>Overview</CardHeader>
+            <CardContent className="pl-2">
+              <Overview data={mockGraphData} />
+            </CardContent>
+          </Card>
+          <div className="col-span-1">
+            <Heading title="Some recent figures" description="We have made 114 sales this week!"/>
+            <RecentSales />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
 export default AdminPage;

--- a/components/contributorCard.tsx
+++ b/components/contributorCard.tsx
@@ -38,7 +38,7 @@ const ContributorCard: React.FC<ContributorCardProps> = ({ contributor , hasNext
       </div>
 
       <div className="relative inline-block">
-        <img
+        <Image
           alt={`Profile of ${contributor.login}`}
           className="rounded-full border-8 border-customTeal dark:border-Green transform transition-transform duration-300 hover:scale-110 cursor-pointer"
           onClick={() => window.open(contributor.html_url, "_blank")}

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -53,6 +53,11 @@ const Links = [
     id: 9,
     href: "/contributors",
   },
+  {
+    name: "Forum",
+    id: 10,
+    href: "/forum",
+  },
 ];
 
 const Footer = () => {

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { getToken } from 'next-auth/jwt';
+
+export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // Check if the route is /admin/auth and skip it
+  if (pathname.startsWith('/admin/auth')) {
+    return NextResponse.next();
+  }
+
+  // Check if the pathname starts with /admin/ followed by an adminId
+  const isAdminRoute = pathname.startsWith('/admin/');
+
+  if (isAdminRoute) {
+    // Get the token from the request
+    const token = await getToken({
+      req: request,
+      secret: process.env.NEXTAUTH_SECRET,
+    });
+    // Redirect to home if the token doesn't exist, the role is not 'admin', or the AdminId is missing
+    if (!token|| token.role !== 'admin' || !token.uid) {
+      return NextResponse.redirect(new URL('/', request.url));
+    }
+  }
+
+  // Continue to the page if the user is authorized
+  return NextResponse.next();
+}
+
+// Specify the paths where this middleware applies
+export const config = {
+  matcher: ['/admin/:adminId*'],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "react-hook-form": "^7.53.0",
         "react-hot-toast": "^2.4.1",
         "react-leaflet": "^4.2.1",
+        "recharts": "^2.13.3",
         "tailwind-merge": "^2.5.3",
         "tailwindcss-animate": "^1.0.7",
         "zod": "^3.23.8"
@@ -1700,6 +1701,69 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-P2dlU/q51fkOc/Gfl3Ul9kicV7l+ra934qBFXCFhrZMOL6du1TM0pm1ThYvENukyOn5h9v+yMJ9Fn5JK4QozrQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.8.tgz",
+      "integrity": "sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.6.tgz",
+      "integrity": "sha512-5KKk5aKGu2I+O6SONMYSNflgiP0WfZIQvVUMan50wHsLG1G94JlxEVnCpQARfTtzytuY0p/9PXXZb3I7giofIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.3.tgz",
+      "integrity": "sha512-2p6olUZ4w3s+07q3Tm2dbiMZy5pCDfYwtLXXHUnVzXgQlZ/OyPtUz6OL382BkOuGlLXqfT+wqv8Fw2v8/0geBw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/geojson": {
       "version": "7946.0.14",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
@@ -3126,6 +3190,127 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -3213,6 +3398,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/decode-uri-component": {
       "version": "0.4.1",
@@ -3375,6 +3566,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/eastasianwidth": {
@@ -4090,12 +4291,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.0.1.tgz",
+      "integrity": "sha512-WF1Wi8PwwSY7/6Kx0vKXtw8RwuSGoM1bvDaJbu7MxDlR1vovZjIAKrnzyrThgAjm6JDTu0fVgWXDlMGspodfoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -4805,6 +5021,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -5454,6 +5679,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -6470,7 +6701,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -6607,7 +6837,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-leaflet": {
@@ -6671,6 +6900,21 @@
         }
       }
     },
+    "node_modules/react-smooth": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.1.tgz",
+      "integrity": "sha512-OE4hm7XqR0jNOq3Qmk9mFLyd6p2+j6bvbPJ7qlB7+oo0eNcL2l7WQzG6MBnT3EXY6xzkLMUBec3AfewJdA0J8w==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-style-singleton": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
@@ -6692,6 +6936,22 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
       }
     },
     "node_modules/read-cache": {
@@ -6728,6 +6988,44 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/recharts": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.13.3.tgz",
+      "integrity": "sha512-YDZ9dOfK9t3ycwxgKbrnDlRC4BHdjlY73fet3a0C1+qGMjXVZe6+VXmpOIIhzkje5MMEL8AN4hLIe4AMskBzlA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.0",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.6",
@@ -7518,6 +7816,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7844,6 +8148,28 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react-hook-form": "^7.53.0",
     "react-hot-toast": "^2.4.1",
     "react-leaflet": "^4.2.1",
+    "recharts": "^2.13.3",
     "tailwind-merge": "^2.5.3",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.23.8"


### PR DESCRIPTION
# Add Admin Dashboard Page with Metrics and Recent Sales

## Description
This PR introduces an **Admin Dashboard** page that displays key website metrics, including total revenue, sales, associated stores, customers, website visits, and successful orders. Additionally, the dashboard provides an overview of sales trends throughout the year and recent sales activity. The data displayed is currently mocked for demonstration purposes.

### Changes:
- **Admin Dashboard Page**:
  - Added a new dashboard layout displaying various statistics:
    - **Total Revenue**: ₹ 2,10,789
    - **Sales**: 577 sales made
    - **Stores Associated**: 43 stores
    - **Customer Associated**: 1450 customers
    - **Website Visits**: 100,223 visits
    - **Successful Orders**: 20,455+ orders
  - Cards are styled and formatted to match the overall design of the website.

- **Overview and Recent Sales**:
  - Added a graph component to show sales data over the last 12 months (mocked data).
  - Displayed a list of recent sales with the relevant details such as name, email, sale amount, and store name.

### Mock Data:
The data shown on the dashboard is currently mock data for testing purposes:
- **Graph Data**: Shows monthly sales data from January to December.
- **Recent Sales Data**: Displays a list of recent sales including the names of customers, their email addresses, sale amounts, and associated stores.

THE PAGE IS FULLY RESPONSIVE AS DEMONSTATED IN THE SCREEN RECORDING BELOW

## Screenshots

- **Admin Dashboard**:


https://github.com/user-attachments/assets/aa7b131b-ceeb-4b4c-a9a8-2021a3e5b564


## Related Issues
- Fixes #1097 